### PR TITLE
Changes the supabase client with the recommended auth helper, @supabase/ssr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,12 @@
         "": {
             "name": "sk-supabase-auth",
             "version": "0.0.1",
+            "dependencies": {
+                "@supabase/ssr": "^0.1.0"
+            },
             "devDependencies": {
                 "@playwright/test": "^1.28.1",
+                "@supabase/supabase-js": "^2.39.8",
                 "@sveltejs/adapter-auto": "next",
                 "@sveltejs/kit": "next",
                 "@typescript-eslint/eslint-plugin": "^5.45.0",
@@ -803,6 +807,85 @@
             "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
             "dev": true
         },
+        "node_modules/@supabase/functions-js": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+            "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/gotrue-js": {
+            "version": "2.62.2",
+            "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+            "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/node-fetch": {
+            "version": "2.6.15",
+            "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+            "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/@supabase/postgrest-js": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+            "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/realtime-js": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
+            "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14",
+                "@types/phoenix": "^1.5.4",
+                "@types/ws": "^8.5.10",
+                "ws": "^8.14.2"
+            }
+        },
+        "node_modules/@supabase/ssr": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.1.0.tgz",
+            "integrity": "sha512-bIVrkqjAK5G3KjkIMKYKtAOlCgRRplEWjrlyRyXSOYtgDieiOhk2ZyNAPsEOa1By9OZVxuX5eAW1fitdnuxayw==",
+            "dependencies": {
+                "cookie": "^0.5.0",
+                "ramda": "^0.29.0"
+            },
+            "peerDependencies": {
+                "@supabase/supabase-js": "^2.33.1"
+            }
+        },
+        "node_modules/@supabase/storage-js": {
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+            "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+            "dependencies": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "node_modules/@supabase/supabase-js": {
+            "version": "2.39.8",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.39.8.tgz",
+            "integrity": "sha512-WpiawHjseIRcCQTZbMJtHUSOepz5+M9qE1jP9BDmg8X7ehALFwgEkiKyHAu59qm/pKP2ryyQXLtu2XZNRbUarw==",
+            "dependencies": {
+                "@supabase/functions-js": "2.1.5",
+                "@supabase/gotrue-js": "2.62.2",
+                "@supabase/node-fetch": "2.6.15",
+                "@supabase/postgrest-js": "1.9.2",
+                "@supabase/realtime-js": "2.9.3",
+                "@supabase/storage-js": "2.5.5"
+            }
+        },
         "node_modules/@sveltejs/adapter-auto": {
             "version": "1.0.0-next.90",
             "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-1.0.0-next.90.tgz",
@@ -895,8 +978,12 @@
         "node_modules/@types/node": {
             "version": "18.11.13",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-            "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
-            "dev": true
+            "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w=="
+        },
+        "node_modules/@types/phoenix": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.4.tgz",
+            "integrity": "sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA=="
         },
         "node_modules/@types/pug": {
             "version": "2.0.6",
@@ -918,6 +1005,14 @@
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
             "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
             "dev": true
+        },
+        "node_modules/@types/ws": {
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+            "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "5.46.0",
@@ -1467,7 +1562,6 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
             "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -3455,6 +3549,15 @@
                 }
             ]
         },
+        "node_modules/ramda": {
+            "version": "0.29.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.1.tgz",
+            "integrity": "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA==",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ramda"
+            }
+        },
         "node_modules/readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3970,6 +4073,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "node_modules/tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -4214,6 +4322,20 @@
                 }
             }
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4243,6 +4365,26 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
+        },
+        "node_modules/ws": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/yallist": {
             "version": "4.0.0",
@@ -4667,6 +4809,79 @@
             "integrity": "sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==",
             "dev": true
         },
+        "@supabase/functions-js": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.1.5.tgz",
+            "integrity": "sha512-BNzC5XhCzzCaggJ8s53DP+WeHHGT/NfTsx2wUSSGKR2/ikLFQTBCDzMvGz/PxYMqRko/LwncQtKXGOYp1PkPaw==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/gotrue-js": {
+            "version": "2.62.2",
+            "resolved": "https://registry.npmjs.org/@supabase/gotrue-js/-/gotrue-js-2.62.2.tgz",
+            "integrity": "sha512-AP6e6W9rQXFTEJ7sTTNYQrNf0LCcnt1hUW+RIgUK+Uh3jbWvcIST7wAlYyNZiMlS9+PYyymWQ+Ykz/rOYSO0+A==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/node-fetch": {
+            "version": "2.6.15",
+            "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+            "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
+        "@supabase/postgrest-js": {
+            "version": "1.9.2",
+            "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.9.2.tgz",
+            "integrity": "sha512-I6yHo8CC9cxhOo6DouDMy9uOfW7hjdsnCxZiaJuIVZm1dBGTFiQPgfMa9zXCamEWzNyWRjZvupAUuX+tqcl5Sw==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/realtime-js": {
+            "version": "2.9.3",
+            "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.9.3.tgz",
+            "integrity": "sha512-lAp50s2n3FhGJFq+wTSXLNIDPw5Y0Wxrgt44eM5nLSA3jZNUUP3Oq2Ccd1CbZdVntPCWLZvJaU//pAd2NE+QnQ==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14",
+                "@types/phoenix": "^1.5.4",
+                "@types/ws": "^8.5.10",
+                "ws": "^8.14.2"
+            }
+        },
+        "@supabase/ssr": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.1.0.tgz",
+            "integrity": "sha512-bIVrkqjAK5G3KjkIMKYKtAOlCgRRplEWjrlyRyXSOYtgDieiOhk2ZyNAPsEOa1By9OZVxuX5eAW1fitdnuxayw==",
+            "requires": {
+                "cookie": "^0.5.0",
+                "ramda": "^0.29.0"
+            }
+        },
+        "@supabase/storage-js": {
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.5.5.tgz",
+            "integrity": "sha512-OpLoDRjFwClwc2cjTJZG8XviTiQH4Ik8sCiMK5v7et0MDu2QlXjCAW3ljxJB5+z/KazdMOTnySi+hysxWUPu3w==",
+            "requires": {
+                "@supabase/node-fetch": "^2.6.14"
+            }
+        },
+        "@supabase/supabase-js": {
+            "version": "2.39.8",
+            "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.39.8.tgz",
+            "integrity": "sha512-WpiawHjseIRcCQTZbMJtHUSOepz5+M9qE1jP9BDmg8X7ehALFwgEkiKyHAu59qm/pKP2ryyQXLtu2XZNRbUarw==",
+            "requires": {
+                "@supabase/functions-js": "2.1.5",
+                "@supabase/gotrue-js": "2.62.2",
+                "@supabase/node-fetch": "2.6.15",
+                "@supabase/postgrest-js": "1.9.2",
+                "@supabase/realtime-js": "2.9.3",
+                "@supabase/storage-js": "2.5.5"
+            }
+        },
         "@sveltejs/adapter-auto": {
             "version": "1.0.0-next.90",
             "resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-1.0.0-next.90.tgz",
@@ -4741,8 +4956,12 @@
         "@types/node": {
             "version": "18.11.13",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-            "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
-            "dev": true
+            "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w=="
+        },
+        "@types/phoenix": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.4.tgz",
+            "integrity": "sha512-B34A7uot1Cv0XtaHRYDATltAdKx0BvVKNgYNqE4WjtPUa4VQJM7kxeXcVKaH+KS+kCmZ+6w+QaUdcljiheiBJA=="
         },
         "@types/pug": {
             "version": "2.0.6",
@@ -4764,6 +4983,14 @@
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
             "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
             "dev": true
+        },
+        "@types/ws": {
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+            "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "5.46.0",
@@ -5103,8 +5330,7 @@
         "cookie": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-            "dev": true
+            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -6426,6 +6652,11 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
+        "ramda": {
+            "version": "0.29.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.1.tgz",
+            "integrity": "sha512-OfxIeWzd4xdUNxlWhgFazxsA/nl3mS4/jGZI5n00uWOoSSFRhC1b6gl6xvmzUamgmqELraWp0J/qqVlXYPDPyA=="
+        },
         "readdirp": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -6757,6 +6988,11 @@
             "integrity": "sha512-eM+pCBxXO/njtF7vdFsHuqb+ElbxqtI4r5EAvk6grfAFyJ6IvWlSkfZ5T9ozC6xWw3Fj1fGoSmrl0gUs46JVIw==",
             "dev": true
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "tslib": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -6883,6 +7119,20 @@
                 "vite": "^3.0.0 || ^4.0.0"
             }
         },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6903,6 +7153,12 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true
+        },
+        "ws": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "requires": {}
         },
         "yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.28.1",
+        "@supabase/supabase-js": "^2.39.8",
         "@sveltejs/adapter-auto": "next",
         "@sveltejs/kit": "next",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
@@ -37,5 +38,8 @@
         "vite": "^4.0.0",
         "vitest": "^0.25.3"
     },
-    "type": "module"
+    "type": "module",
+    "dependencies": {
+        "@supabase/ssr": "^0.1.0"
+    }
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,9 +1,20 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
+
+import type { Session, SupabaseClient } from '@supabase/supabase-js';
+
 // and what to do when importing types
-declare namespace App {
-	// interface Error {}
-	// interface Locals {}
-	// interface PageData {}
-	// interface Platform {}
+declare global {
+	declare namespace App {
+		// interface Error {}
+		interface Locals {
+			supabase: SupabaseClient;
+			session: Session | null;
+			getSession: () => Promise<Session | null>;
+		}
+		interface PageData {
+			session: Session | null;
+		}
+		// interface Platform {}
+	}
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,26 @@
+import type { Handle } from '@sveltejs/kit';
+import { createSupabaseServerClient } from '$lib/supabase';
+import type { Session } from '@supabase/supabase-js';
+
+export const handle: Handle = async ({ event, resolve }) => {
+	event.locals.supabase = createSupabaseServerClient(event);
+
+	const getSession = async (): Promise<Session | null> => {
+		const { data: getUserData, error: err } = await event.locals.supabase.auth.getUser();
+		let {
+			data: { session }
+		} = await event.locals.supabase.auth.getSession();
+
+		if (getUserData.user == null || err) {
+			session = null;
+		}
+		return session;
+	};
+
+	event.locals.session = await getSession();
+
+	const response = await resolve(event, {
+		filterSerializedResponseHeaders: (name) => name == 'content-page'
+	});
+	return response;
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,43 @@
+import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '$env/static/public';
+import {
+	combineChunks,
+	createBrowserClient,
+	createServerClient,
+	isBrowser,
+	parse
+} from '@supabase/ssr';
+import type { Cookies } from '@sveltejs/kit';
+
+export const createSupabaseServerClient = ({ cookies }: { cookies: Cookies }) => {
+	return createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+		cookies: {
+			get: (key) => cookies.get(key),
+			set: (key, value, option) => {
+				cookies.set(key, value, { ...option, path: '/' });
+			},
+			remove: (key, option) => {
+				cookies.delete(key, { ...option, path: '/' });
+			}
+		}
+	});
+};
+
+export const createSupabaseBrowserClient = ({ data }: { data: Record<string, any> | null }) => {
+	return createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+		global: {
+			fetch
+		},
+		cookies: {
+			get(key) {
+				if (!isBrowser()) {
+					return JSON.stringify(data?.session);
+				}
+				const cookie = combineChunks(key, (name) => {
+					const cookies = parse(document.cookie);
+					return cookies[name];
+				});
+				return cookie;
+			}
+		}
+	});
+};

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,7 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async (event) => {
+	let session = event.locals.session;
+
+	return { session };
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,30 @@
-<script>
+<script lang="ts">
+	import { onMount } from 'svelte';
 	import '../app.postcss';
+	import type { LayoutData } from './$types';
+	import { goto, invalidate, invalidateAll } from '$app/navigation';
+
+	export let data: LayoutData;
+	$: ({ supabase } = data);
+
+	onMount(async () => {
+		const {
+			data: { subscription }
+		} = supabase.auth.onAuthStateChange(() => {
+			invalidate('supabase:auth');
+			invalidateAll();
+		});
+		return () => subscription.unsubscribe();
+	});
+
+	const submitLogout = async ({ cancel }: { cancel: CallableFunction }) => {
+		const { error } = await supabase.auth.signOut();
+		if (error) {
+			console.log(error);
+		}
+		cancel();
+		await goto('/');
+	};
 </script>
 
 <slot />

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,13 @@
+import { createSupabaseBrowserClient } from '$lib/supabase';
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ data, depends }) => {
+	depends('supabase:auth');
+
+	const supabase = createSupabaseBrowserClient({ data });
+	const {
+		data: { session }
+	} = await supabase.auth.getSession();
+
+	return { supabase, session };
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,31 @@
+<script lang="ts">
+	import { enhance, type SubmitFunction } from '$app/forms';
+	import { createSupabaseBrowserClient } from '$lib/supabase';
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const submitLogout: SubmitFunction = async ({ cancel, data }) => {
+		const { error } = await createSupabaseBrowserClient({ data }).auth.signOut();
+		if (error) {
+			console.log(error);
+		}
+		cancel();
+	};
+</script>
+
 <main>
 	<h1>SvelteKit & Supabase Auth</h1>
-	<p>Let's learn how to register and login users!</p>
-	<div class="auth-buttons">
-		<a href="/login" class="btn btn-primary">Login</a>
-		<a href="/register" class="btn btn-secondary">Register</a>
-	</div>
+	{#if data.session}
+		<p>Welcome, {data.session.user.email}</p>
+		<form method="POST" action="/logout" use:enhance={submitLogout}>
+			<button style="margin-top: .5rem;" type="submit" class="btn btn-primary">Logout here</button>
+		</form>
+	{:else}
+		<p>Let's learn how to register and login users!</p>
+		<div class="auth-buttons">
+			<a href="/login" class="btn btn-primary">Login</a>
+			<a href="/register" class="btn btn-secondary">Register</a>
+		</div>
+	{/if}
 </main>

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,29 @@
+import { AuthApiError } from '@supabase/supabase-js';
+import { fail, type Actions, redirect } from '@sveltejs/kit';
+
+export const actions: Actions = {
+	login: async ({ request, locals }) => {
+		const formData = Object.fromEntries(await request.formData());
+
+		if (!formData.email || !formData.password) {
+			return fail(400, { error: 'Email or Password Required to login.' });
+		}
+
+		const { error: err } = await locals.supabase.auth.signInWithPassword({
+			email: formData.email as string,
+			password: formData.password as string
+		});
+
+		if (err) {
+			if (err instanceof AuthApiError && err.status === 400) {
+				return fail(400, { error: 'Invalid Credential' });
+			}
+
+			return fail(500, {
+				message: 'Server error, please try again.'
+			});
+		}
+
+		throw redirect(303, '/');
+	}
+};

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,7 +3,7 @@
 
 <main>
 	<h1>Login</h1>
-	<form action="" class="auth-form">
+	<form action="?/login" method="POST" class="auth-form">
 		<label for=""> Email </label>
 		<input type="text" name="email" />
 		<label for=""> Password </label>

--- a/src/routes/logout/+server.ts
+++ b/src/routes/logout/+server.ts
@@ -1,0 +1,11 @@
+import { error, redirect, type RequestHandler } from '@sveltejs/kit';
+
+export const POST: RequestHandler = async ({ locals }) => {
+	const { error: err } = await locals.supabase.auth.signOut();
+
+	if (err) {
+		error(500, 'Something went wrong logging you out.');
+	}
+
+	throw redirect(303, '/');
+};

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -1,0 +1,28 @@
+import { AuthApiError } from '@supabase/supabase-js';
+import { fail, type Actions, redirect } from '@sveltejs/kit';
+
+export const actions: Actions = {
+	register: async ({ request, locals }) => {
+		const formData = Object.fromEntries(await request.formData());
+
+		const { error: err } = await locals.supabase.auth.signUp({
+			email: formData.email as string,
+			password: formData.password as string
+		});
+
+		console.log(formData, err);
+		if (err) {
+			if (err instanceof AuthApiError && err.status == 400) {
+				return fail(400, {
+					error: 'Invalid email or password'
+				});
+			}
+
+			return fail(500, {
+				error: 'Something  went wrong, try again later.'
+			});
+		}
+
+		redirect(300, '/');
+	}
+};

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -3,7 +3,7 @@
 
 <main>
 	<h1>Register</h1>
-	<form action="" class="auth-form">
+	<form action="?/register" method="POST" class="auth-form">
 		<label for=""> Email </label>
 		<input type="text" name="email" />
 		<label for=""> Password </label>


### PR DESCRIPTION
You probably know that in Supabase's official documentation, they no longer support auth-helpers; instead, they recommend using the new helper called @supabase/ssr, which generally divides between server-side and browser-side clients. 

And with these changes, I recreated the same app with the new auth-helpers package.


I'm not an English native speaker🙌.